### PR TITLE
Fix: favicons command has no attribute cli.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ pep8-naming = "^0.11.1"
 pre-commit = "^2.6.0"
 
 [tool.poetry.scripts]
-favicons = "favicons:cli"
+favicons = "favicons.cli:cli"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Hi, Matt,

Thank you for the package.

This pull request is to fix a bug when executing the favicons command. It's just a minor change in pyproject.toml.

The bug occurs with the package published on PyPI:

```
favicons                       
Traceback (most recent call last):
  File "[edited]/favicons/env/bin/favicons", line 8, in <module>
    sys.exit(cli())
TypeError: 'module' object is not callable

```
And also with the master branch:
```
pip install .
poetry run favicons
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'favicons' has no attribute 'cli'
```

It will be great if you can merge it and publish a new version on PyPI!