### PR TITLE
Replace svglib with cairosvg

### DIFF
--- a/favicons/_generate.py
+++ b/favicons/_generate.py
@@ -115,7 +115,8 @@ class Favicons:
     def _check_source_format(self) -> None:
         """Convert source image to PNG if it's in SVG format."""
         if self._source.suffix == ".svg":
-            self._source = svg_to_png(self._source, self.background_color)
+            bg: Tuple[int, ...] = self.background_color.colors
+            self._source = svg_to_png(self._source, bg, self.transparent)
 
     @staticmethod
     def _get_center_point(background: PILImage, foreground: PILImage) -> Tuple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,14 @@ license = "BSD-3-Clause-Clear"
 name = "favicons"
 readme = "README.md"
 repository = "https://github.com/thatmattlove/favicons"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 pillow = "^10.2.0"
 python = ">=3.10.0,<4.0"
-reportlab = "^4.1.0"
 rich = "^13.7.0"
-svglib = "^1.5.1"
 typer = "^0.9.0"
-rlpycairo = "^0.3.0"
+cairosvg = "^2.7.0"
 
 [tool.poetry.scripts]
 favicons = "favicons:cli"


### PR DESCRIPTION
`svglib` has a pretty severe limitation, in that it [cannot handle SVGs with linear gradients](https://github.com/deeplook/svglib/issues/336). Also replacing `svglib` with `cairosvg` reduces the number of external dependencies by a few, since the project no longer requires `reportlab` or `rlpycairo` either.