### PR TITLE
Fix alpha blending

### DIFF
--- a/favicons/_generate.py
+++ b/favicons/_generate.py
@@ -115,7 +115,8 @@ class Favicons:
     def _check_source_format(self) -> None:
         """Convert source image to PNG if it's in SVG format."""
         if self._source.suffix == ".svg":
-            self._source = svg_to_png(self._source, self.background_color)
+            bg: Tuple[int, ...] = self.background_color.colors
+            self._source = svg_to_png(self._source, bg, self.transparent)
 
     @staticmethod
     def _get_center_point(background: PILImage, foreground: PILImage) -> Tuple:

--- a/favicons/_generate.py
+++ b/favicons/_generate.py
@@ -125,7 +125,7 @@ class Favicons:
             bg: Tuple[int, ...] = self.background_color.colors + ((255,),(0,))[self.transparent]
 
             # Composite source image on top of background color.
-            src = PILImage.alpha_composite(PILImage.new("RGBA", src.size, bg), src)
+            src = PILImage.alpha_composite(PILImage.new("RGBA", src.size, bg), src.convert("RGBA"))
 
             # Resize source image without changing aspect ratio, and pad with bg color.
             src = ImageOps.pad(src, size=format_properties.dimensions, color=bg)

--- a/favicons/_util.py
+++ b/favicons/_util.py
@@ -39,7 +39,7 @@ def generate_icon_types() -> Generator[FaviconProperties, None, None]:
             yield FaviconProperties(**icon_type)
 
 
-def svg_to_png(svg_path: Path, background_color: Color, transparent: bool) -> Path:
+def svg_to_png(svg_path: Path) -> Path:
     """Convert an SVG vector to a PNG file."""
     import io
     # Third Party
@@ -50,14 +50,6 @@ def svg_to_png(svg_path: Path, background_color: Color, transparent: bool) -> Pa
 
     png = Path(png_path)
 
-    png_bytes = svg2png(svg_path.read_bytes())
-    if transparent:
-        png.write_bytes(png_bytes)
-    else:
-        with PILImage.open(io.BytesIO(png_bytes)) as src:
-            bg_image = PILImage.new("RGBA", src.size, background_color)
-            composite = PILImage.alpha_composite(bg_image, src)
-
-        composite.save(str(png))
+    png.write_bytes(svg2png(svg_path.read_bytes()))
 
     return png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,14 @@ license = "BSD-3-Clause-Clear"
 name = "favicons"
 readme = "README.md"
 repository = "https://github.com/thatmattlove/favicons"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 pillow = "^10.2.0"
 python = ">=3.10.0,<4.0"
-reportlab = "^4.1.0"
 rich = "^13.7.0"
-svglib = "^1.5.1"
 typer = "^0.9.0"
-rlpycairo = "^0.3.0"
+cairosvg = "^2.7.0"
 
 [tool.poetry.scripts]
 favicons = "favicons:cli"


### PR DESCRIPTION
This fixes a couple of issues with icon generation.

1) The transparency option only affects the created border around an icon - post patch, the icon is alpha blended with the desired background color
2) The icon is only reduced from the input image size, not enlarged - post patch, the icon will fill the desired area and padded with the appropriate color to maintain the aspect ratio of the image.
3) Alpha blending was occurring twice, once during SVG to PNG conversion and again on resize. This removes the alpha blending from the svg conversion step.

This pull request incorporates #11 (sorry if that's lazy).
